### PR TITLE
fix: incorrect custum prompt string

### DIFF
--- a/src/main/java/jadx/plugins/xvision/XVisionPlugin.java
+++ b/src/main/java/jadx/plugins/xvision/XVisionPlugin.java
@@ -199,9 +199,6 @@ public class XVisionPlugin implements JadxPlugin {
     private String showPromptDialog(String code) {
         String defaultPrompt = getDefaultPrompt();
 
-        if (!defaultPrompt.contains("%s")) {
-            defaultPrompt = defaultPrompt + "\n\n%s";
-        }
         JPanel panel = new JPanel(new BorderLayout(5, 5));
         panel.setBorder(new EmptyBorder(10, 10, 10, 10));
 
@@ -268,12 +265,9 @@ public class XVisionPlugin implements JadxPlugin {
 
                 if (useCustomPromptCheckbox.isSelected()) {
                     customPrompt = customPromptArea.getText();
-                    if (!customPrompt.contains("%s")) {
-                        customPrompt = customPrompt + "\n\n%s";
-                    }
-                    return String.format(customPrompt, code);
+                    return String.format(customPrompt + "\n\n%s", code);
                 } else {
-                    return String.format(defaultPrompt, code);
+                    return String.format(defaultPrompt + "\n\n%s", code);
                 }
             }
             return null;


### PR DESCRIPTION
fixed the issue of additional '%s' string being displayed in the custom prompt dialog when the formatted string was concatenated with the format, causing the previous custom prompt to be displayed incorrectly.

![image](https://github.com/user-attachments/assets/6a222a4e-1e95-48ca-b0ce-beb8c9f76482)